### PR TITLE
Allow to reconnect controller

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change Log
 ==========
 
 * :support:`-` Basic documentation.
+* :feature:`10` Add actor command ``reconnect`` that allows to recreate the TCP/IP connection to one or multiple controllers. If the controller cannot be connected when the actor starts, a warning is issued but the actor will be created.
 
 * :release:`0.1.0 <2021-03-06>`
 * Initial version of the library and actor. Supports communication with the Archon controller, Archon command tracking and reply parsing, and basic actor functionality, including exposing.

--- a/archon/actor/commands/reconnect.py
+++ b/archon/actor/commands/reconnect.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2021-03-07
+# @Filename: reconnect.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+import asyncio
+
+import click
+from clu.command import Command
+
+from archon.actor.commands import parser
+from archon.actor.tools import parallel_controllers
+from archon.controller.controller import ArchonController
+
+
+@parser.command()
+@click.option("--timeout", "-t", type=float, help="Time to wait while (dis)connecting.")
+@parallel_controllers(check=False)
+async def reconnect(command: Command, controller: ArchonController, timeout: float):
+    """Restarts the socket connection to the controller(s)."""
+
+    name = controller.name
+    connect_timeout = timeout or command.actor.config["timeouts"]["controller_connect"]
+
+    if controller.is_connected():
+        try:
+            await asyncio.wait_for(controller.stop(), timeout=timeout or 1)
+        except BaseException as err:
+            command.warning(
+                text=f"Failed disconnecting from {name!r} with "
+                f"error {err}. Will try to reconnect."
+            )
+
+    try:
+        await asyncio.wait_for(controller.start(), timeout=connect_timeout)
+    except asyncio.TimeoutError:
+        command.error(error=f"Timed-out while reconnecting to controller {name!r}.")
+        return False
+    except BaseException as err:
+        command.error(
+            error=f"Unexpected error while connecting to controller {name!r}: {err}"
+        )
+        return False
+
+    return True

--- a/archon/actor/tools.py
+++ b/archon/actor/tools.py
@@ -100,8 +100,9 @@ def parallel_controllers(check=True):
                     p.cancel()
                 return command.fail("Some tasks raised exceptions.")
 
-            if False in done:
-                return command.fail("Some controllers failed.")
+            results = [task.result() for task in done]
+            if False in results:
+                return command.fail(error="Some controllers failed.")
             return command.finish()
 
         return functools.update_wrapper(wrapper, f)

--- a/archon/actor/tools.py
+++ b/archon/actor/tools.py
@@ -38,7 +38,7 @@ controller_list = click.option(
 )
 
 
-def parallel_controllers():
+def parallel_controllers(check=True):
     """A decarator that executes the same command for multiple controllers.
 
     When decorated with `.parallel_controllers`, the command gets an additional option
@@ -84,10 +84,11 @@ def parallel_controllers():
 
             tasks: list[asyncio.Task] = []
             for k in controller_keys:
-                if k not in controllers:
-                    return command.fail(f"Invalid controller {k!r}.")
-                if not controllers[k].is_connected():
-                    return command.fail(f"Controller {k!r} is not connected.")
+                if check:
+                    if k not in controllers:
+                        return command.fail(f"Invalid controller {k!r}.")
+                    if not controllers[k].is_connected():
+                        return command.fail(f"Controller {k!r} is not connected.")
                 tasks.append(asyncio.create_task(f(command, controllers[k], **kwargs)))
 
             done, pending = await asyncio.wait(

--- a/archon/etc/archon.yml
+++ b/archon/etc/archon.yml
@@ -28,6 +28,7 @@ files:
   template: 'sdR-{hemisphere}-{controller}-{exposure_no:08d}.fits.gz'
 
 timeouts:
+  controller_connect: 1
   readout_expected: 45
   readout_max: 60
   fetching_expected: 5


### PR DESCRIPTION
Adds the ability to reconnect a controller and times out with a warning if the controller cannot be connected when the actor starts.