### PR TITLE
New spectrograph readout features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### ✨ Improved
 
 * Added `expose --async-readout` flag that finishes the expose command as soon as readout begins.
+* Added `wait-until-idle` command that returns once the spectrographs are idle.
 
 
 ## 0.9.0 - April 13, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### ✨ Improved
+
+* Added `expose --async-readout` flag that finishes the expose command as soon as readout begins.
+
+
 ## 0.9.0 - April 13, 2023
 
 ### 🚀 New

--- a/archon/actor/commands/expose.py
+++ b/archon/actor/commands/expose.py
@@ -197,21 +197,22 @@ async def expose(
                 # expose will fail the command.
                 return
 
-            readout_task = asyncio.create_task(
-                delegate.readout(
-                    command,
-                    extra_header=extra_header,
-                    delay_readout=delay_readout,
+            if readout is True:
+                readout_task = asyncio.create_task(
+                    delegate.readout(
+                        command,
+                        extra_header=extra_header,
+                        delay_readout=delay_readout,
+                    )
                 )
-            )
 
-            if async_readout and n == count and n_flavour == len(flavours) - 1:
-                return command.finish("Returning while readout is ongoing.")
+                if async_readout and n == count and n_flavour == len(flavours) - 1:
+                    return command.finish("Returning while readout is ongoing.")
 
-            readout_result = await readout_task
+                readout_result = await readout_task
 
-            if not readout_result:
-                return
+                if not readout_result:
+                    return
 
     return command.finish()
 

--- a/archon/controller/controller.py
+++ b/archon/controller/controller.py
@@ -1097,6 +1097,7 @@ class ArchonController(Device):
         if delay > 0:
             await self.set_param("WaitCount", delay)
 
+        print("here")
         self.update_status(ControllerStatus.READOUT_PENDING, "off", notify=False)
         self.update_status(ControllerStatus.READING)
 

--- a/archon/controller/controller.py
+++ b/archon/controller/controller.py
@@ -1097,7 +1097,6 @@ class ArchonController(Device):
         if delay > 0:
             await self.set_param("WaitCount", delay)
 
-        print("here")
         self.update_status(ControllerStatus.READOUT_PENDING, "off", notify=False)
         self.update_status(ControllerStatus.READING)
 

--- a/tests/actor/conftest.py
+++ b/tests/actor/conftest.py
@@ -14,7 +14,6 @@ import numpy
 import pytest
 import pytest_asyncio
 from clu.actor import AMQPBaseActor
-from more_itertools import side_effect
 
 from sdsstools import merge_config, read_yaml_file
 

--- a/tests/actor/conftest.py
+++ b/tests/actor/conftest.py
@@ -14,12 +14,14 @@ import numpy
 import pytest
 import pytest_asyncio
 from clu.actor import AMQPBaseActor
+from more_itertools import side_effect
 
 from sdsstools import merge_config, read_yaml_file
 
 from archon import config
 from archon.actor import ArchonActor
 from archon.controller.controller import ArchonController
+from archon.controller.maskbits import ControllerStatus
 
 
 @pytest.fixture()
@@ -55,7 +57,16 @@ async def actor(test_config: dict, controller: ArchonController, mocker):
 
 @pytest.fixture()
 def delegate(actor: ArchonActor, monkeypatch, tmp_path: pathlib.Path, mocker):
-    mocker.patch.object(actor.controllers["sp1"], "readout")
+    def reset_status(**kwargs):
+        actor.controllers["sp1"].update_status(ControllerStatus.IDLE)
+        actor.controllers["sp1"].update_status(ControllerStatus.READOUT_PENDING, "off")
+
+    mocker.patch.object(
+        actor.controllers["sp1"],
+        "readout",
+        return_value=True,
+        side_effect=reset_status,
+    )
 
     # For framemode=top
     mocker.patch.object(

--- a/tests/actor/test_command_expose.py
+++ b/tests/actor/test_command_expose.py
@@ -235,9 +235,12 @@ async def test_expose_set_window(delegate, actor: ArchonActor):
 
 async def test_expose_with_dark(delegate, actor: ArchonActor, mocker):
     expose_mock = mocker.patch.object(delegate, "expose", return_value=True)
+    mocker.patch.object(delegate, "readout", return_value=True)
 
     command = await actor.invoke_mock_command("expose --with-dark 0.01")
     await command
+
+    assert command.status.did_succeed
 
     expose_mock.assert_called()
     assert expose_mock.call_count == 2

--- a/tests/actor/test_command_expose.py
+++ b/tests/actor/test_command_expose.py
@@ -232,7 +232,7 @@ async def test_expose_set_window(delegate, actor: ArchonActor):
 
     filename = delegate.actor.model["filenames"].value[0]
     hdu = fits.open(filename)
-    assert hdu[0].data.shape == (200, 200)
+    assert hdu[0].data.shape == (200, 200)  # type: ignore
 
 
 async def test_expose_with_dark(delegate, actor: ArchonActor, mocker):


### PR DESCRIPTION
* Added `expose --async-readout` flag that finishes the expose command as soon as readout begins.
* Added `wait-until-idle` command that returns once the spectrographs are idle.