### PR TITLE
Allow to use fitsio to save files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade wheel pip setuptools
-          pip install .
+          pip install .[fitsio]
 
       - name: Lint with ruff
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### 🚀 New
+
+* [#45](https://github.com/sdss/archon/issues/45) Added a new option `files.write_engine` that can be set to `astropy` or `fitsio`. In the latter case it will use fitsio to write images to disk. This requires installing `sdss-archon` with the `fitsio` extra (e.g., `pip install sdss-archon[fitsio]`).
+
+
 ## 0.11.6 - November 24, 2023
 
 ### 🏷️ Changed

--- a/archon/__init__.py
+++ b/archon/__init__.py
@@ -7,7 +7,7 @@ from sdsstools import get_config, get_logger, get_package_version
 NAME = "sdss-archon"
 
 # Loads config. config name is the package name.
-config = get_config("archon")
+config = get_config("archon", allow_user=False)
 
 # Inits the logging system as NAME. Remove all the handlers. If a client
 # of the library wants the archon logging, it should add its own handler.

--- a/archon/actor/delegate.py
+++ b/archon/actor/delegate.py
@@ -20,12 +20,13 @@ from tempfile import NamedTemporaryFile
 from time import time
 from unittest.mock import MagicMock
 
-from typing import TYPE_CHECKING, Any, Dict, Generic, List, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Dict, Generic, List, Sequence, TypeVar, cast
 
 import astropy.time
 import numpy
 from astropy.io import fits
 
+from sdsstools.configuration import Configuration
 from sdsstools.time import get_sjd
 
 from archon import __version__
@@ -58,6 +59,8 @@ class ExposureDelegate(Generic[Actor_co]):
 
         self._command: Command[Actor_co] | None = None
         self._expose_cotasks: asyncio.Task | None = None
+
+        self._check_fitsio()
 
     @property
     def command(self):
@@ -298,14 +301,14 @@ class ExposureDelegate(Generic[Actor_co]):
             self.reset()
             return True
 
-        c_to_hdus: dict[ArchonController, list[fits.PrimaryHDU]]
+        c_to_hdus: dict[ArchonController, list[dict[str, Any]]]
         c_to_hdus = {controllers[ii]: hdus[ii] for ii in range(len(controllers))}
 
         post_process_jobs = []
         for controller, hdus in c_to_hdus.items():
             post_process_jobs.append(self.post_process(controller, hdus))
-
         c_to_hdus = dict(list(await asyncio.gather(*post_process_jobs)))
+
         self.command.debug(text="Writing HDUs to file.")
         await asyncio.gather(*[self.write_hdus(c, h) for c, h in c_to_hdus.items()])
 
@@ -353,25 +356,25 @@ class ExposureDelegate(Generic[Actor_co]):
         self.expose_data.header["BUFFER"] = (buffer_no, "The buffer number read")
 
         controller_info = config["controllers"][controller.name]
-        hdus = []
+        hdus: list[dict[str, Any]] = []
         for ccd_name in controller_info["detectors"]:
             header = await self.build_base_header(controller, ccd_name)
             ccd_data = self._get_ccd_data(data, controller, ccd_name, controller_info)
-            hdus.append(fits.PrimaryHDU(data=ccd_data, header=header))
+            hdus.append({"data": ccd_data, "header": header})
 
         return hdus
 
     async def write_hdus(
         self,
         controller: ArchonController,
-        hdus: List[fits.PrimaryHDU],
+        hdus: list[dict[str, Any]],
     ):
         """Writes HDUs to disk."""
 
         assert self.expose_data
 
         expose_data = self.expose_data
-        config = self.actor.config
+        config = Configuration(self.actor.config)
 
         excluded_cameras = config.get("excluded_cameras", [])
 
@@ -380,7 +383,7 @@ class ExposureDelegate(Generic[Actor_co]):
 
         write_tasks = []
         for _, hdu in enumerate(hdus):
-            ccd = cast(str, hdu.header["ccd"])
+            ccd = cast(str, hdu["header"]["CCD"][0])
 
             if ccd in excluded_cameras:
                 self.command.warning(f"Not saving image for camera {ccd}.")
@@ -388,12 +391,8 @@ class ExposureDelegate(Generic[Actor_co]):
 
             file_path = self._get_ccd_filepath(controller, ccd)
 
-            hdu.header["filename"] = os.path.basename(file_path)
-            hdu.header.insert(
-                "filename",
-                ("EXPOSURE", expose_data.exposure_no, "Exposure number"),
-                after=True,
-            )
+            hdu["header"]["FILENAME"][0] = os.path.basename(file_path)
+            hdu["header"]["EXPOSURE"][0] = expose_data.exposure_no
 
             write_tasks.append(
                 self._write_to_file(
@@ -432,11 +431,11 @@ class ExposureDelegate(Generic[Actor_co]):
 
     async def _write_to_file(
         self,
-        hdu: fits.PrimaryHDU,
+        data: dict[str, Any],
         file_path: str,
         write_async: bool = True,
     ):
-        """Writes the HDU to file using an executor.
+        """Writes the HDU to file using astropy or fitsio.
 
         The file is first written to a temporary file with the same path and
         name as the final file but with a random suffix, and then renamed.
@@ -446,10 +445,17 @@ class ExposureDelegate(Generic[Actor_co]):
         if os.path.exists(file_path):
             raise FileExistsError(f"Cannot overwrite file {file_path}.")
 
-        loop = asyncio.get_running_loop()
+        loop = asyncio.get_event_loop()
 
-        writeto = partial(hdu.writeto, checksum=True)
-        temp_file = NamedTemporaryFile(suffix=".fits", delete=False).name
+        write_engine: str = self.actor.config["files"].get("write_engine", "astropy")
+        if write_engine == "astropy":
+            writeto = partial(self._write_file_astropy, data)
+        elif write_engine == "fitsio":
+            writeto = partial(self._write_file_fitsio, data)
+        else:
+            raise ValueError(f"Invalid write engine {write_engine!r}.")
+
+        temp_file = NamedTemporaryFile(suffix=".fits", delete=True).name
 
         if write_async:
             if file_path.endswith(".gz"):
@@ -484,6 +490,36 @@ class ExposureDelegate(Generic[Actor_co]):
             os.unlink(temp_file)
 
         return file_path
+
+    def _write_file_astropy(self, data: dict[str, Any], file_path: str):
+        """Writes the HDU to file using astropy."""
+
+        header = fits.Header()
+        for key, value in data["header"].items():
+            header[key] = tuple(value) if isinstance(value, (list, tuple)) else value
+
+        hdu = fits.PrimaryHDU(data["data"], header=header)
+        hdu.writeto(file_path, checksum=True, overwrite=True)
+
+        return
+
+    def _write_file_fitsio(self, data: dict[str, Any], file_path: str):
+        """Writes the HDU to file using astropy."""
+
+        import fitsio
+
+        header = []
+        for key, value in data["header"].items():
+            if isinstance(value, Sequence):
+                header.append({"name": key, "value": value[0], "comment": value[1]})
+            else:
+                header.append({"name": key, "value": value, "comment": ""})
+
+        with fitsio.FITS(file_path, "rw") as fits_:
+            fits_.write(data["data"], header=header, clobber=True)
+            fits_[-1].write_checksum()
+
+        return
 
     async def _generate_checksum(self, filenames: list[str]):
         """Generates a checksum file for the images written to disk."""
@@ -527,8 +563,8 @@ class ExposureDelegate(Generic[Actor_co]):
     async def post_process(
         self,
         controller: ArchonController,
-        hdus: list[fits.PrimaryHDU],
-    ) -> tuple[ArchonController, list[fits.PrimaryHDU]]:
+        hdus: list[dict[str, Any]],
+    ) -> tuple[ArchonController, list[dict[str, Any]]]:
         """Custom post-processing."""
 
         return (controller, hdus)
@@ -541,11 +577,12 @@ class ExposureDelegate(Generic[Actor_co]):
         expose_data = self.expose_data
         assert expose_data.end_time is not None
 
-        header = fits.Header()
+        header: dict[str, tuple[Any, str] | Any] = {}
 
         # Basic header
         header["V_ARCHON"] = __version__
-        header["FILENAME"] = ("", "File basename")  # Will be filled out later
+        header["FILENAME"] = ["", "File basename"]  # Will be filled out later
+        header["EXPOSURE"] = [None, "Exposure number"]  # Will be filled out later
         header["SPEC"] = (controller.name, "Spectrograph name")
         header["OBSERVAT"] = (self.command.actor.observatory, "Observatory")
         header["OBSTIME"] = (expose_data.start_time.isot, "Start of the observation")
@@ -558,15 +595,18 @@ class ExposureDelegate(Generic[Actor_co]):
 
         header["CCD"] = (ccd_name, "CCD name")
 
-        config = self.actor.config
-        if (
-            "controllers" not in config or controller.name not in config["controllers"]
-        ):  # pragma: no cover
+        config = Configuration(self.actor.config)
+        controller_config = config[f"controllers.{controller.name}"]
+        if controller_config is None:  # pragma: no cover
             self.command.warning(text="Cannot retrieve controller information.")
-            controller_config = {"detectors": {ccd_name: {}}, "parameters": {}}
-        else:
-            controller_config = config["controllers"][controller.name]
-        ccd_config = controller_config["detectors"][ccd_name]
+            controller_config = Configuration(
+                {
+                    "detectors": {ccd_name: {}},
+                    "parameters": {},
+                }
+            )
+
+        ccd_config = controller_config[f"detectors.{ccd_name}"]
 
         ccdid = ccd_config.get("serial", "?")
         ccdtype = ccd_config.get("type", "?")
@@ -845,6 +885,19 @@ class ExposureDelegate(Generic[Actor_co]):
             raise ValueError(f"Framemode {framemode} is not supported at this time.")
 
         return ccd_data
+
+    def _check_fitsio(self):
+        """Checks if fitsio is installed and needed."""
+
+        write_engine: str = self.actor.config["files"].get("write_engine", "astropy")
+        if write_engine == "fitsio":
+            try:
+                import fitsio  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "fitsio is required to use fitsio. You can install "
+                    "it with 'pip install fitsio' or 'pip install sdss-archon[fitsio]'."
+                )
 
 
 @dataclass

--- a/archon/etc/archon.yml
+++ b/archon/etc/archon.yml
@@ -17,7 +17,8 @@ timeouts:
 files:
   data_dir: '~/'
   template: 'sdR-{ccd}-{exposure_no:08d}.fits.gz'
-  write_async: false
+  write_async: true
+  write_engine: astropy
 
 archon:
   default_parameters: {}

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 80%
         if_not_found: success
         if_ci_failed: error
         informational: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -595,6 +595,19 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pyt
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
+name = "fitsio"
+version = "1.2.1"
+description = "A full featured python library to read from and write to FITS files."
+optional = true
+python-versions = "*"
+files = [
+    {file = "fitsio-1.2.1.tar.gz", hash = "sha256:c64f60588f25fb2ba499854082bca73b0eda43b32ed6091f09dfcbcb72a911a6"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[[package]]
 name = "furo"
 version = "2023.9.10"
 description = "A clean customisable Sphinx documentation theme."
@@ -797,13 +810,13 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jsonschema-specifications"
-version = "2023.11.1"
+version = "2023.11.2"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jsonschema_specifications-2023.11.1-py3-none-any.whl", hash = "sha256:f596778ab612b3fd29f72ea0d990393d0540a5aab18bf0407a46632eab540779"},
-    {file = "jsonschema_specifications-2023.11.1.tar.gz", hash = "sha256:c9b234904ffe02f079bf91b14d79987faa685fd4b39c377a0996954c0090b9ca"},
+    {file = "jsonschema_specifications-2023.11.2-py3-none-any.whl", hash = "sha256:e74ba7c0a65e8cb49dc26837d6cfe576557084a8b423ed16a420984228104f93"},
+    {file = "jsonschema_specifications-2023.11.2.tar.gz", hash = "sha256:9472fc4fea474cd74bea4a2b190daeccb5a9e4db2ea80efcf7a1b582fc9a81b8"},
 ]
 
 [package.dependencies]
@@ -1947,13 +1960,13 @@ websocket = ["websockets (>=11.0.3,<12.0.0)"]
 
 [[package]]
 name = "sdsstools"
-version = "1.4.0"
+version = "1.5.2"
 description = "Small tools for SDSS products"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = ">=3.8,<3.13"
 files = [
-    {file = "sdsstools-1.4.0-py3-none-any.whl", hash = "sha256:3ebd183fe6a7d67c53fbbcbdac192d3263bfefa57955ab0644612a5baeedda29"},
-    {file = "sdsstools-1.4.0.tar.gz", hash = "sha256:cd1920f1d32d1bdf71be68c045d5c288955f947d47fc2cc7ca46debd6d49036a"},
+    {file = "sdsstools-1.5.2-py3-none-any.whl", hash = "sha256:172b618145e2fe45b202582f4905e3d3689756bb99e2aab906bc64c33f1774ee"},
+    {file = "sdsstools-1.5.2.tar.gz", hash = "sha256:d238f65b3562df8af6a3ce3307635799f363bf9c3e7e730ac77b9f67244ef0e6"},
 ]
 
 [package.dependencies]
@@ -2559,7 +2572,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[extras]
+fitsio = ["fitsio"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.13"
-content-hash = "62b2e8b9f727d3b7b97dc1e30fd510ef7007923527e5d0b7020f0fbc84fb8372"
+content-hash = "d7dc5a16d1b9b5abc0e532aa6fd8fb830261c8270834ccd2714b292b9bfed4f1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ fast = true
 line-length = 88
 target-version = 'py311'
 select = ["E", "F", "I"]
+exclude = ["__init__.pyi"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F403", "F401", "E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,12 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.13"
-sdsstools = "^1.0.2"
+sdsstools = "^1.5.2"
 numpy = "^1.26.1"
 sdss-clu = "^2.0.0b2"
 click-default-group = "^1.2.2"
 astropy = "^6.0"
+fitsio = {version = "^1.2.1", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 ipython = [
@@ -55,6 +56,9 @@ nox = ">=2021.6.12"
 sphinx-autobuild = ">=2021.3.14"
 sphinx-copybutton = ">=0.3.3"
 ruff = ">=0.0.284"
+
+[tool.poetry.extras]
+fitsio = ["fitsio"]
 
 [tool.black]
 line-length = 88

--- a/tests/actor/conftest.py
+++ b/tests/actor/conftest.py
@@ -71,7 +71,7 @@ def delegate(actor: ArchonActor, monkeypatch, tmp_path: pathlib.Path, mocker):
     mocker.patch.object(
         actor.controllers["sp1"],
         "fetch",
-        return_value=(numpy.ones((1000, 1000)), 1),
+        return_value=(numpy.ones((1000, 3000)), 1),
     )
 
     assert actor.model

--- a/tests/actor/test_command_reconnect.py
+++ b/tests/actor/test_command_reconnect.py
@@ -7,6 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
 import asyncio
+from unittest import mock
 
 from archon.actor import ArchonActor
 from archon.exceptions import ArchonError
@@ -20,15 +21,14 @@ async def test_reconnect(actor: ArchonActor):
     assert len(command.replies) == 2
 
 
-async def test_reconnect_stop_fails(actor: ArchonActor, mocker):
-    mocker.patch.object(
+async def test_reconnect_stop_fails(actor: ArchonActor):
+    with mock.patch.object(
         actor.controllers["sp1"],
         "stop",
-        side_effect=[ArchonError, None, None],  # stop() is also called on tear down.
-    )
-
-    command = await actor.invoke_mock_command("reconnect")
-    await command
+        side_effect=ArchonError,
+    ):
+        command = await actor.invoke_mock_command("reconnect")
+        await command
 
     assert command.status.did_fail  # Fails because the controller is still connected.
     assert len(command.replies) == 4

--- a/tests/actor/test_delegate.py
+++ b/tests/actor/test_delegate.py
@@ -23,7 +23,14 @@ from archon.exceptions import ArchonControllerError, ArchonError
 
 
 @pytest.mark.parametrize("flavour", ["bias", "dark", "object"])
-async def test_delegate_expose(delegate: ExposureDelegate, flavour: str):
+@pytest.mark.parametrize("write_engine", ["astropy", "fitsio"])
+async def test_delegate_expose(
+    delegate: ExposureDelegate,
+    flavour: str,
+    write_engine: bool,
+):
+    delegate.actor.config["files"]["write_engine"] = write_engine
+
     command = Command("", actor=delegate.actor)
     result = await delegate.expose(
         command,

--- a/tests/actor/test_delegate.py
+++ b/tests/actor/test_delegate.py
@@ -321,3 +321,11 @@ async def test_deletage_post_process(delegate: ExposureDelegate, mocker: MockerF
     hdu = fits.open(filename)
 
     assert hdu[0].header["TEST"] == 1
+
+
+async def test_delegate_no_fitsio(actor: ArchonActor, mocker: MockerFixture):
+    mocker.patch.dict("sys.modules", {"fitsio": None})
+    actor.config["files"]["write_engine"] = "fitsio"
+
+    with pytest.raises(ImportError):
+        ExposureDelegate(actor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ import asyncio
 import configparser
 import os
 import re
-import tempfile
 import types
 
 from typing import Iterable, Tuple, Union

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ CommandsType = Iterable[Tuple[str, Iterable[Union[str, bytes]]]]
 
 
 @pytest_asyncio.fixture()
-async def controller(request, unused_tcp_port: int, mocker):
+async def controller(request, unused_tcp_port: int):
     """Mocks a `.ArchonController` that replies to commands with predefined replies.
 
     Tests that use this fixture must be decorated with ``@pytest.mark.commands``. The
@@ -46,7 +46,8 @@ async def controller(request, unused_tcp_port: int, mocker):
         commands: CommandsType = []
 
     async def handle_connection(
-        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
     ) -> None:
         while True:
             try:
@@ -92,13 +93,16 @@ async def controller(request, unused_tcp_port: int, mocker):
                     writer.write(f"<{cid}\n".encode())
                 await writer.drain()
 
+        writer.close()
+        await writer.wait_closed()
+
     server = await asyncio.start_server(handle_connection, "localhost", unused_tcp_port)
 
     async with server:
         archon = ArchonController("sp1", "localhost", unused_tcp_port)
 
         config["archon"]["default_parameters"]["Exposures"] = 0
-        config.CONFIG_FILE = tempfile.NamedTemporaryFile().name
+        # config._CONFIG_FILE = tempfile.NamedTemporaryFile().name
 
         archon.start = types.MethodType(start_archon, archon)
 

--- a/tests/controller/test_config.py
+++ b/tests/controller/test_config.py
@@ -114,7 +114,7 @@ async def test_read_config_save(controller: ArchonController, mocker, path):
     assert len(config) == 5
     assert config[0] == "LINE0=0"
 
-    assert open_patch.called_once()
+    open_patch.assert_called_once()
 
 
 @pytest.fixture()

--- a/typings/astropy/__init__.pyi
+++ b/typings/astropy/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/typings/astropy/coordinates/__init__.pyi
+++ b/typings/astropy/coordinates/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/typings/astropy/io/__init__.pyi
+++ b/typings/astropy/io/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/typings/astropy/io/fits/__init__.pyi
+++ b/typings/astropy/io/fits/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...

--- a/typings/astropy/time/__init__.pyi
+++ b/typings/astropy/time/__init__.pyi
@@ -1,0 +1,3 @@
+from typing import Any
+
+def __getattr__(name: str) -> Any: ...


### PR DESCRIPTION
Introduces a new option `files.write_engine` that can be set to `astropy` or `fitsio`. In the latter case it will use fitsio to write images to disk. This requires installing `sdss-archon` with the `fitsio` extra (e.g., `pip install sdss-archon[fitsio]`.