### PR TITLE
Implement image recovery system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * As part of [#46](https://github.com/sdss/archon/issues/46) `ExposureDelegate.post_process()` is now called once for each controller CCD with a `FetchDataDict` as the only argument. The function must modify the input dictionary in place and return `None`.
 
+### 🚀 New
+
+* [#47](https://github.com/sdss/archon/issues/47) Added a framework for recovering images when they fail to be written to disk. A lockfile is created when the buffer is read which can be used to recover the original image and header. Recovery happens automatically when the actor starts or via the `recover` command.
+
 ### ⚙️ Engineering
 
 * [#46](https://github.com/sdss/archon/issues/46) Significant clean-up of the `ExposureDelegate` code.

--- a/archon/actor/actor.py
+++ b/archon/actor/actor.py
@@ -234,13 +234,15 @@ class ArchonBaseActor(BaseActor):
             return
 
         with self.exposure_recovery.set_command(self):
-            await self.exposure_recovery.recover(
+            recovered = await self.exposure_recovery.recover(
                 self.config["controllers"],
                 path=mjd_dir,
                 write_checksum=self.config["checksum.write"],
                 checksum_mode=self.config["checksum.mode"],
                 checksum_file=self.config["checksum.file"],
             )
+
+        return recovered
 
 
 class ArchonActor(ArchonBaseActor, AMQPActor):

--- a/archon/actor/actor.py
+++ b/archon/actor/actor.py
@@ -60,6 +60,7 @@ class ArchonBaseActor(BaseActor):
         self,
         *args,
         controllers: tuple[ArchonController, ...] = (),
+        run_recovery_on_start: bool = True,
         **kwargs,
     ):
         #: dict[str, ArchonController]: A mapping of controller name to controller.
@@ -83,6 +84,8 @@ class ArchonBaseActor(BaseActor):
         # self.timed_commands.add_command("system", delay=60)  # type: ignore
 
         self.exposure_delegate = self.DELEGATE_CLASS(self)
+
+        self.run_recovery_on_start = run_recovery_on_start
         self.exposure_recovery = ExposureRecovery(self.controllers)
 
         self._fetch_log_jobs = []
@@ -126,7 +129,7 @@ class ArchonBaseActor(BaseActor):
         # Depending on how the actor is initialised exposure_recovery may not have
         # been set with the actual controllers.
         self.exposure_recovery.controllers = self.controllers
-        if self.config.get("actor.run_recovery_on_start", True):
+        if self.run_recovery_on_start:
             await self._recover_exposures()
 
     async def stop(self):

--- a/archon/actor/commands/__init__.py
+++ b/archon/actor/commands/__init__.py
@@ -6,49 +6,21 @@
 # @Filename: __init__.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
-import glob
-import importlib
-import os
+from __future__ import annotations
 
-import click
+from clu.parsers.click import command_parser as parser
 
-from clu.parsers.click import (
-    CluGroup,
-    get_command_model,
-    get_schema,
-    help_,
-    keyword,
-    ping,
-    version,
-)
-
-
-@click.group(cls=CluGroup)
-def parser(*args):
-    pass
-
-
-parser.add_command(ping)
-parser.add_command(version)
-parser.add_command(help_)
-parser.add_command(get_schema)
-parser.add_command(keyword)
-parser.add_command(get_command_model)
-
-
-# Autoimport all modules in this directory so that they are added to the parser.
-
-exclusions = ["__init__.py"]
-
-cwd = os.getcwd()
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-
-files = [
-    file_ for file_ in glob.glob("**/*.py", recursive=True) if file_ not in exclusions
-]
-
-for file_ in files:
-    modname = file_[0:-3].replace("/", ".")
-    mod = importlib.import_module("archon.actor.commands." + modname)
-
-os.chdir(cwd)
+from .config import config
+from .disconnect import disconnect
+from .expose import abort, expose, read, wait_until_idle
+from .flush import flush
+from .frame import frame
+from .init import init
+from .power import power
+from .reconnect import reconnect
+from .recover import recover
+from .reset import reset
+from .status import status
+from .system import system
+from .talk import talk
+from .window import get_window, set_window

--- a/archon/actor/commands/expose.py
+++ b/archon/actor/commands/expose.py
@@ -182,6 +182,11 @@ async def expose(
     if count > 1 and readout is False:
         return command.fail(error="--count > 1 requires readout.")
 
+    # Wait for any ongoing recovery to finish.
+    if not command.actor.exposure_recovery.locker.is_set():
+        command.warning("Waiting for image recovery to finish.")
+        await command.actor.exposure_recovery.locker.wait()
+
     for nexp in range(1, count + 1):
         flavours = [flavour, "dark"] if with_dark else [flavour]
         for nf, this_flavour in enumerate(flavours):
@@ -256,6 +261,11 @@ async def read(
         return command.fail(error="Cannot find expose delegate.")
 
     extra_header = json.loads(header)
+
+    # Wait for any ongoing recovery to finish.
+    if not command.actor.exposure_recovery.locker.is_set():
+        command.warning("Waiting for image recovery to finish.")
+        await command.actor.exposure_recovery.locker.wait()
 
     result = await delegate.readout(
         command,

--- a/archon/actor/commands/recover.py
+++ b/archon/actor/commands/recover.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2023-12-01
+# @Filename: recover.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import pathlib
+
+from typing import TYPE_CHECKING
+
+import astropy.time
+import click
+
+from sdsstools import get_sjd
+
+from . import parser
+
+
+if TYPE_CHECKING:
+    from archon.actor.actor import ArchonCommandType
+    from archon.controller.controller import ArchonController
+
+
+@parser.command()
+@click.argument("PATH", type=str, required=False)
+@click.option(
+    "--write-checksum",
+    is_flag=True,
+    help="Adds the checksum of the recovered files to the checksum file.",
+)
+@click.option(
+    "--keep-lock",
+    is_flag=True,
+    help="Do not remove the lockfile.",
+)
+async def recover(
+    command: ArchonCommandType,
+    controllers: dict[str, ArchonController],
+    path: str | None = None,
+    write_checksum: bool = False,
+    keep_lock: bool = False,
+):
+    """Recovers a failed exposure.
+
+    PATH is either the path to the lockfile of the missing exposure or a directory
+    for which all available lockfiles will be recovered. If PATH is not provided the
+    default path will be used.
+
+    """
+
+    config = command.actor.config
+
+    if path is None:
+        now = astropy.time.Time.now()
+        mjd = get_sjd() if config.get("files.use_sjd", False) else int(now.mjd)
+        data_dir = pathlib.Path(config.get("files.data_dir", "/data"))
+
+        recovery_path = data_dir / str(mjd)
+
+    else:
+        recovery_path = pathlib.Path(path)
+
+    if not recovery_path.exists():
+        return command.fail(f"Path {recovery_path!s} does not exist. Recovery failed.")
+
+    with command.actor.exposure_recovery.set_command(command):
+        recovered = await command.actor.exposure_recovery.recover(
+            config["controllers"],
+            path=recovery_path,
+            write_checksum=write_checksum,
+            checksum_mode=config["checksum.mode"],
+            checksum_file=config["checksum.file"],
+            delete_lock=not keep_lock,
+        )
+
+    if len(recovered) == 0:
+        command.info("No exposures were recovered.")
+
+    command.finish(filenames=[str(fn) for fn in recovered])

--- a/archon/actor/delegate.py
+++ b/archon/actor/delegate.py
@@ -357,7 +357,7 @@ class ExposureDelegate(Generic[Actor_co]):
         await asyncio.gather(*post_process_jobs)
 
         # Update save-point file after post-processing.
-        self._update_save_point(fdata)
+        self.actor.exposure_recovery.update(fdata)
 
         excluded_cameras: list[str] = self.config.get("excluded_cameras", [])
         write_engine: str = self.config.get("files.write_engine", "astropy")
@@ -395,8 +395,7 @@ class ExposureDelegate(Generic[Actor_co]):
                 # write coroutines crashes the actor.
                 if isinstance(result, str):
                     fn = result
-                    with self.actor.exposure_recovery.set_command(self.command):
-                        self.actor.exposure_recovery.unlink(fn)
+                    self.actor.exposure_recovery.unlink(fn)
 
                     # Update checksum file.
                     if write_checksum:
@@ -491,7 +490,7 @@ class ExposureDelegate(Generic[Actor_co]):
             )
 
         # Create a save-point file.
-        self._update_save_point(ccd_dict)
+        self.actor.exposure_recovery.update(ccd_dict)
 
         return ccd_dict
 
@@ -966,9 +965,3 @@ class ExposureDelegate(Generic[Actor_co]):
                     "fitsio is required to use fitsio. You can install "
                     "it with 'pip install fitsio' or 'pip install sdss-archon[fitsio]'."
                 )
-
-    def _update_save_point(self, fdata: FetchDataDict | list[FetchDataDict]):
-        """Updates the save-point file for a set of cameras."""
-
-        with self.actor.exposure_recovery.set_command(self.command):
-            self.actor.exposure_recovery.update(fdata)

--- a/archon/actor/delegate.py
+++ b/archon/actor/delegate.py
@@ -400,11 +400,15 @@ class ExposureDelegate(Generic[Actor_co]):
 
                     # Update checksum file.
                     if write_checksum:
-                        await self._generate_checksum(
-                            checksum_file,
-                            [fn],
-                            mode=checksum_mode,
-                        )
+                        try:
+                            await self._generate_checksum(
+                                checksum_file,
+                                [fn],
+                                mode=checksum_mode,
+                            )
+                        except Exception as err:
+                            self.command.warning(str(err))
+                            continue
 
             except Exception as err:
                 write_results.append(err)

--- a/archon/actor/delegate.py
+++ b/archon/actor/delegate.py
@@ -41,6 +41,7 @@ from sdsstools.time import get_sjd
 from archon import __version__
 from archon.controller.controller import ArchonController
 from archon.controller.maskbits import ControllerStatus
+from archon.exceptions import ArchonError
 from archon.tools import gzip_async, subprocess_run_async
 
 
@@ -61,6 +62,7 @@ class FetchDataDict(TypedDict):
     """Dictionary of fetched data."""
 
     controller: str
+    buffer: int
     ccd: str
     data: DataArray
     header: dict[str, list]
@@ -162,7 +164,7 @@ class ExposureDelegate(Generic[Actor_co]):
         window_params: dict = {},
         seqno: int | None = None,
         **readout_params,
-    ):
+    ) -> bool:
         self.command = command
 
         if self.lock.locked():
@@ -348,45 +350,82 @@ class ExposureDelegate(Generic[Actor_co]):
         for cf in c_fdata:
             fdata += cf
 
-        self.command.debug(text="Running post-processing.")
+        self.command.debug(text="Calling post-process routine.")
         post_process_jobs = []
         for fdata_ccd in fdata:
             post_process_jobs.append(self.post_process(fdata_ccd))
         await asyncio.gather(*post_process_jobs)
 
+        # Update save-point file after post-processing.
+        self._update_save_point(fdata)
+
+        excluded_cameras: list[str] = self.config.get("excluded_cameras", [])
+        write_engine: str = self.config.get("files.write_engine", "astropy")
+        write_async: bool = self.config.get("files.write_async", True)
+
         self.command.debug(text="Writing data to file.")
         write_results: list = []
+        write_coros = [
+            self.write_to_disk(
+                fd,
+                excluded_cameras=excluded_cameras,
+                write_async=write_async,
+                write_engine=write_engine,
+            )
+            for fd in fdata
+        ]
+
+        # Prepare checksum information.
+        write_checksum: bool = self.config["checksum.write"]
+        checksum_mode: str = self.config.get("checksum.mode", "md5")
+        checksum_file = self.config.get("checksum.file", f"{{SJD}}.{checksum_mode}sum")
+        checksum_file: str = checksum_file.format(SJD=get_sjd())
 
         if self.config.get("files.write_async", True):
-            write_results = await asyncio.gather(
-                *map(self.write_to_disk, fdata),
-                return_exceptions=True,
-            )
+            coro_iter = asyncio.as_completed(write_coros)
         else:
-            for fd in fdata:
-                try:
-                    write_results.append(await self.write_to_disk(fd))
-                except Exception as err:
-                    write_results.append(err)
+            coro_iter = write_coros
+
+        for coro in coro_iter:
+            try:
+                result = await coro
+                write_results.append(result)
+
+                # Delete save-point. We do it here because in case one of the
+                # write coroutines crashes the actor.
+                if isinstance(result, str):
+                    fn = result
+                    with self.actor.exposure_recovery.set_command(self.command):
+                        self.actor.exposure_recovery.unlink(fn)
+
+                    # Update checksum file.
+                    if write_checksum:
+                        await self._generate_checksum(
+                            checksum_file,
+                            [fn],
+                            mode=checksum_mode,
+                        )
+
+            except Exception as err:
+                write_results.append(err)
 
         filenames: list[str] = []
         failed_to_write: bool = False
         for ii, result in enumerate(write_results):
             fn = fdata[ii]["filename"]
+            ccd = fdata[ii]["ccd"]
+
             if isinstance(result, str):
                 filenames.append(result)
-            elif result is False:
-                self.command.error(f"Failed writting {fn!s} to disk.")
-                failed_to_write = True
+
             elif isinstance(result, Exception):
                 self.command.error(f"Failed to writting {fn!s} to disk: {result!s}")
                 failed_to_write = True
-            else:
-                # This should mean the CCD was in excluded_cameras.
-                continue
+
+            elif result is None:
+                self.command.warning(f"Not saving image for camera {ccd!r}.")
 
         self.command.info(filenames=filenames)
-        await self._generate_checksum(filenames)
 
         self.reset()
 
@@ -438,6 +477,7 @@ class ExposureDelegate(Generic[Actor_co]):
             ccd_dict.append(
                 {
                     "controller": controller.name,
+                    "buffer": buffer_no,
                     "ccd": ccd_name,
                     "data": ccd_data,
                     "header": ccd_header,
@@ -446,45 +486,42 @@ class ExposureDelegate(Generic[Actor_co]):
                 }
             )
 
+        # Create a save-point file.
+        self._update_save_point(ccd_dict)
+
         return ccd_dict
 
-    async def write_to_disk(self, ccd_data: FetchDataDict) -> bool | str | None:
+    @staticmethod
+    async def write_to_disk(
+        ccd_data: FetchDataDict,
+        excluded_cameras: list[str] = [],
+        write_async: bool = True,
+        write_engine: str = "astropy",
+    ) -> str | None:
         """Writes ccd data to disk."""
 
-        assert self.expose_data
-        expose_data = self.expose_data
-
-        # Check if the CCD is in the list of excluded cameras. If so, return.
-        excluded_cameras = self.config.get("excluded_cameras", [])
-
+        # Check if the CCD is in the list of excluded cameras. If so, raise.
         ccd = ccd_data["ccd"]
         if ccd in excluded_cameras:
-            self.command.warning(f"Not saving image for camera {ccd}.")
             return None
 
         # Check file path and update header with exposure number and file name.
         file_path = ccd_data["filename"]
 
         if os.path.exists(file_path):
-            self.command.error(f"Cannot overwrite file {file_path}.")
-            return False
+            raise ArchonError(f"Cannot overwrite file {file_path}.")
 
         header = ccd_data["header"]
         header["FILENAME"][0] = os.path.basename(file_path)
-        header["EXPOSURE"][0] = expose_data.exposure_no
+        header["EXPOSURE"][0] = ccd_data["exposure_no"]
 
         # Determine which engine to use to save the data.
-        write_engine: str = self.config.get("files.write_engine", "astropy")
         if write_engine == "astropy":
-            writeto = partial(self._write_file_astropy, ccd_data)
+            writeto = partial(ExposureDelegate._write_file_astropy, ccd_data)
         elif write_engine == "fitsio":
-            writeto = partial(self._write_file_fitsio, ccd_data)
+            writeto = partial(ExposureDelegate._write_file_fitsio, ccd_data)
         else:
-            self.command.error(f"Invalid write engine {write_engine!r}.")
-            return False
-
-        # Determine whether to write the file using an asynchronous executor.
-        write_async = self.config.get("files.write_async", True)
+            raise ArchonError(f"Invalid write engine {write_engine!r}.")
 
         # Name of the temporary file where the data will be written to first.
         temp_file = NamedTemporaryFile(suffix=".fits", delete=True).name
@@ -506,24 +543,23 @@ class ExposureDelegate(Generic[Actor_co]):
                 temp_file = temp_file + ".gz"
 
         if not os.path.exists(temp_file):
-            self.command.error(f"Failed writing image {file_path!s} to disk.")
-            return False
+            raise ArchonError(f"Failed writing image {file_path!s} to disk.")
 
         # Rename to final file.
         try:
             shutil.copyfile(temp_file, file_path)
         except Exception:
-            self.command.error(
+            raise ArchonError(
                 f"Failed renaming temporary file {temp_file}. "
                 "The original file is still available."
             )
-            return False
         else:
             os.unlink(temp_file)
 
         return file_path
 
-    def _write_file_astropy(self, data: FetchDataDict, file_path: str):
+    @staticmethod
+    def _write_file_astropy(data: FetchDataDict, file_path: str):
         """Writes the HDU to file using astropy."""
 
         header = fits.Header()
@@ -535,7 +571,8 @@ class ExposureDelegate(Generic[Actor_co]):
 
         return
 
-    def _write_file_fitsio(self, data: FetchDataDict, file_path: str):
+    @staticmethod
+    def _write_file_fitsio(data: FetchDataDict, file_path: str):
         """Writes the HDU to file using astropy."""
 
         import fitsio
@@ -553,25 +590,18 @@ class ExposureDelegate(Generic[Actor_co]):
 
         return
 
-    async def _generate_checksum(self, filenames: list[str]):
+    @staticmethod
+    async def _generate_checksum(
+        checksum_file: str, filenames: list[str], mode: str = "md5"
+    ):
         """Generates a checksum file for the images written to disk."""
 
-        if self.config["checksum.write"]:
-            checksum_config = self.config["checksum"]
-        else:
-            return
-
-        checksum_mode = checksum_config.get("mode", "md5")
-        if checksum_mode.startswith("sha1"):
+        if mode.startswith("sha1"):
             sum_command = "sha1sum"
-        elif checksum_mode.startswith("md5"):
+        elif mode.startswith("md5"):
             sum_command = "md5sum"
         else:
-            self.command.warning(f"Invalid checksum mode {checksum_mode!r}.")
-            return
-
-        checksum_basefile = checksum_config.get("file", f"{{SJD}}.{checksum_mode}sum")
-        checksum_basefile = checksum_basefile.format(SJD=get_sjd())
+            raise ArchonError(f"Invalid checksum mode {mode!r}.")
 
         for filename in filenames:
             filename = str(filename)
@@ -580,12 +610,12 @@ class ExposureDelegate(Generic[Actor_co]):
 
             try:
                 await subprocess_run_async(
-                    f"{sum_command} {basename} >> {checksum_basefile}",
+                    f"{sum_command} {basename} >> {checksum_file}",
                     shell=True,
                     cwd=dirname,
                 )
             except Exception as err:
-                self.command.warning(f"Failed to generate checksum: {err}")
+                raise ArchonError(f"Failed to generate checksum: {err}")
 
     async def post_process(self, fdata: FetchDataDict):
         """Custom post-processing.
@@ -862,16 +892,14 @@ class ExposureDelegate(Generic[Actor_co]):
 
         return file_path
 
+    @staticmethod
     def _get_ccd_data(
-        self,
         data: numpy.ndarray,
         controller: ArchonController,
         ccd_name: str,
         controller_info: Dict[str, Any],
     ) -> numpy.ndarray:
         """Retrieves the CCD data from the buffer frame."""
-
-        assert self.expose_data
 
         assert controller.acf_config
 
@@ -934,3 +962,9 @@ class ExposureDelegate(Generic[Actor_co]):
                     "fitsio is required to use fitsio. You can install "
                     "it with 'pip install fitsio' or 'pip install sdss-archon[fitsio]'."
                 )
+
+    def _update_save_point(self, fdata: FetchDataDict | list[FetchDataDict]):
+        """Updates the save-point file for a set of cameras."""
+
+        with self.actor.exposure_recovery.set_command(self.command):
+            self.actor.exposure_recovery.update(fdata)

--- a/archon/actor/delegate.py
+++ b/archon/actor/delegate.py
@@ -783,7 +783,7 @@ class ExposureDelegate(Generic[Actor_co]):
                             if len(params) > 1:
                                 comment = params[1]
                             if len(params) > 2:
-                                value = numpy.round(value, params[2])
+                                value = float(numpy.round(value, params[2]))
                         header[kname] = [value, comment]
 
         # Convert JSON lists to tuples or astropy fails.

--- a/archon/actor/recovery.py
+++ b/archon/actor/recovery.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2023-12-01
+# @Filename: recovery.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import asyncio
+import json
+import pathlib
+from contextlib import contextmanager
+from copy import deepcopy
+from os import PathLike
+
+from typing import TYPE_CHECKING, Sequence
+
+from clu.command import Command
+from sdsstools import get_sjd
+
+from archon.actor.delegate import ExposureDelegate
+from archon.controller.controller import ArchonController
+
+
+if TYPE_CHECKING:
+    import nptyping
+
+    from archon.actor.actor import ArchonBaseActor
+    from archon.actor.delegate import FetchDataDict
+
+    BufferDataType = nptyping.NDArray[nptyping.Shape["*,*"], nptyping.UInt]
+
+
+class ExposureRecovery:
+    """A mechanism for recovering exposures that failed to write to disk.
+
+    When the `.ExposureDelegate` finishes reading a buffer and compiling the
+    header, all the metadata (excluding the data itself) is stored in a
+    JSON file with the same name as the final image. During actor start,
+    `.ExposeureRecovery` looks for missing JSON files which indicate
+    FITS files not fully written. If found, the buffer is read again and the
+    FITS file is written to disk using the information stored in the JSON file.
+
+    """
+
+    def __init__(self, controllers: dict[str, ArchonController]) -> None:
+        self.controllers = controllers
+        self._command: Command | ArchonBaseActor | None = None
+
+        # An event that gets cleared (becomes blocking) when the recovery
+        # is in progress. We begin with it being set.
+        self.locker = asyncio.Event()
+        self.locker.set()
+
+    @contextmanager
+    def set_command(self, command: Command | ArchonBaseActor):
+        """Sets the command or actor to use to output messages."""
+
+        self._command = command
+
+        yield
+
+        self._command = None
+
+    def emit(self, message_string: str, level: str = "d"):
+        """Emits a message using the command or actor."""
+
+        if self._command is None:
+            return
+
+        self._command.write(level, message={"text": message_string})
+
+    def update(self, fetch_data: FetchDataDict | Sequence[FetchDataDict]):
+        """Creates/updates the JSON file for a CCD image."""
+
+        fetch_data = self._sequencify(fetch_data)
+
+        for data in fetch_data:
+            json_path = self._get_path(data)
+            json_path.parent.mkdir(parents=True, exist_ok=True)
+
+            dump_data = dict(deepcopy(data))
+            del dump_data["data"]
+
+            # This overwrite the entire JSON file.
+            with open(json_path, "w") as json_file:
+                json.dump(dump_data, json_file, indent=4, sort_keys=True)
+
+            self.emit(f"Created lock JSON file {json_path!s}")
+
+    def unlink(
+        self,
+        input: FetchDataDict | Sequence[FetchDataDict] | str | PathLike,
+        force: bool = False,
+    ):
+        """Removes a JSON file once the FITS file has been written.
+
+        Parameters
+        ----------
+        input
+            The `.FetchDataDict` for the CCD to remove, or a sequence of fetched
+            data. It can also be a single string or path to the FITS file, in which
+            case its corresponding lock file will be deleted.
+        force
+            If ``False``, an error will be raised if the FITS file does not exist.
+
+        Raises
+        ------
+        FileExistsError
+            If the FITS file does not exist and ``force=False``.
+
+        """
+
+        # If we provide a FITS filename we get the lock filename and delete it.
+        if isinstance(input, (str, PathLike)):
+            lock_path = self._get_path(input)
+            lock_path.unlink(missing_ok=True)
+            self.emit(f"Removed lock JSON file {lock_path!s}.")
+            return
+
+        # Otherwise we assume we are passing a FetchDataDict or a sequence of them.
+        fetch_data = self._sequencify(input)
+
+        for data in fetch_data:
+            fits_path = pathlib.Path(data["filename"]).absolute()
+            lock_path = self._get_path(data)
+
+            if force is False:
+                if not fits_path.exists():
+                    raise FileExistsError(
+                        f"FITS file {fits_path!s} does not exist. "
+                        "Not removing the JSON recovery file."
+                    )
+
+            lock_path.unlink(missing_ok=True)
+            self.emit(f"Removed lock JSON file {lock_path!s}.")
+
+    async def recover(
+        self,
+        controller_info: dict,
+        path: str | PathLike | None = None,
+        files: list[str | PathLike] | None = None,
+        delete_json: bool = True,
+        write_async: bool = True,
+        write_engine: str = "astropy",
+        write_checksum: bool = False,
+        checksum_mode: str = "md5",
+        checksum_file: str | None = None,
+        excluded_cameras: list[str] = [],
+    ):
+        """Recovers exposures from a JSON file.
+
+        Parameters
+        ----------
+        controller_info
+            A dictionary with the controller-to-CCD mapping and information.
+        path
+            A directory containing lock files. All lock files found will be recovered.
+        files
+            A list of lock files to recover.
+        delete_json
+            If ``True``, the JSON file will be removed after a successful recovery.
+        write_async
+            Whether to write the FITS file asynchronously.
+        write_engine
+            The engine to use to write the FITS file, either ``astropy`` or ``fitsio``.
+        write_checksum
+            Whether to update the checksum file with the recovered image checksum.
+        checksum_mode
+            The algorithm to use to generate the checksum.
+        checksum_file
+            The name or template for the checksum file. If ``None``, the default is
+            use. The template can contain the ``{SJD}`` keyword, which will be
+            set to the current SJD. The checksum is always relative to the parent
+            directory of the recovered image.
+        excluded_cameras
+            A list of cameras to exclude from the recovery.
+
+        Returns
+        -------
+        filenames
+            A list with the filenames of the recovered images.
+
+        """
+
+        if path is not None and files is not None:
+            raise ValueError("Cannot specify both path and files.")
+
+        if path is not None:
+            path = pathlib.Path(path).absolute()
+            if path.is_dir():
+                lock_files = list(path.glob("*.lock"))
+            else:
+                lock_files = [path]
+        elif files is not None:
+            lock_files = [pathlib.Path(f).absolute() for f in files]
+        else:
+            raise ValueError("Must specify either path or files.")
+
+        buffer_cache: dict[int, BufferDataType] = {}
+        recovered: list[pathlib.Path] = []
+
+        self.locker.clear()
+
+        for lock_file in lock_files:
+            if not lock_file.exists():
+                self.emit(f"Lock file {lock_file!s} does not exist. Skipping.", "w")
+                continue
+
+            with open(lock_file, "r") as json_file:
+                fdata: FetchDataDict = json.loads(json_file.read())
+
+            controller_name = fdata["controller"]
+            if controller_name not in self.controllers:
+                self.emit(f"Cannot find controller {controller_name!r}.", "w")
+                continue
+
+            controller = self.controllers[controller_name]
+
+            buffer = fdata["buffer"]
+            if buffer not in buffer_cache:
+                self.emit(f"Reading buffer {buffer}.")
+                data: BufferDataType = await controller.fetch(buffer_no=buffer)
+                buffer_cache[buffer] = data
+            else:
+                data = buffer_cache[buffer]
+
+            ccd_data = ExposureDelegate._get_ccd_data(
+                data,
+                controller,
+                fdata["ccd"],
+                controller_info[controller.name],
+            )
+            fdata["data"] = ccd_data
+
+            try:
+                filename = fdata["filename"]
+                self.emit(f"Writing recovered exposure {filename!r}.")
+                result = await ExposureDelegate.write_to_disk(
+                    fdata,
+                    write_async=write_async,
+                    write_engine=write_engine,
+                    excluded_cameras=excluded_cameras,
+                )
+            except Exception as err:
+                self.emit(f"Failed to write recovered exposure: {err!r}", "w")
+            else:
+                if result is None:
+                    self.emit(
+                        f"Skipping exposure {filename!r} which is "
+                        "in excluded_cameras.",
+                        "w",
+                    )
+                    continue
+
+                # Update checksum file.
+                if write_checksum:
+                    checksum_file = checksum_file or f"{{SJD}}.{checksum_mode}sum"
+                    checksum_file = checksum_file.format(SJD=get_sjd())
+                    await ExposureDelegate._generate_checksum(
+                        checksum_file,
+                        [filename],
+                        mode=checksum_mode,
+                    )
+
+                self.emit(f"Exposure {filename!r} has been recovered and saved.")
+                recovered.append(pathlib.Path(filename))
+
+                if delete_json:
+                    self.unlink(fdata)
+
+        self.locker.set()
+
+        return recovered
+
+    def _sequencify(self, fetch_data: FetchDataDict | Sequence[FetchDataDict]):
+        """Makes sure ``fetch_data`` is a list of `.FetchDataDict`."""
+
+        if not isinstance(fetch_data, Sequence):
+            fetch_data = [fetch_data]
+        else:
+            fetch_data = list(fetch_data)
+
+        return fetch_data
+
+    def _get_path(self, fetch_data: FetchDataDict | str | PathLike):
+        """Returns the path to the JSON file for a given image."""
+
+        if isinstance(fetch_data, dict):
+            fn = fetch_data["filename"]
+        else:
+            fn = fetch_data
+
+        return pathlib.Path(str(fn) + ".lock").absolute()

--- a/archon/actor/recovery.py
+++ b/archon/actor/recovery.py
@@ -140,7 +140,7 @@ class ExposureRecovery:
         controller_info: dict,
         path: str | PathLike | None = None,
         files: list[str | PathLike] | None = None,
-        delete_json: bool = True,
+        delete_lock: bool = True,
         write_async: bool = True,
         write_engine: str = "astropy",
         write_checksum: bool = False,
@@ -158,7 +158,7 @@ class ExposureRecovery:
             A directory containing lock files. All lock files found will be recovered.
         files
             A list of lock files to recover.
-        delete_json
+        delete_lock
             If ``True``, the JSON file will be removed after a successful recovery.
         write_async
             Whether to write the FITS file asynchronously.
@@ -263,7 +263,7 @@ class ExposureRecovery:
             self.emit(f"Exposure {filename!r} has been recovered and saved.")
             recovered.append(pathlib.Path(filename))
 
-            if delete_json:
+            if delete_lock:
                 self.unlink(fdata)
 
         self.locker.set()

--- a/tests/actor/config.yaml
+++ b/tests/actor/config.yaml
@@ -59,3 +59,4 @@ actor:
   name: archon
   host: localhost
   port: 5672
+  run_recovery_on_start: false

--- a/tests/actor/conftest.py
+++ b/tests/actor/conftest.py
@@ -136,7 +136,7 @@ def fetch_data(tmp_path: pathlib.Path):
         "ccd": "r1",
         "controller": "sp1",
         "exposure_no": 1,
-        "filename": str(tmp_path / str(get_sjd()) / "test.fits"),
+        "filename": str(tmp_path / str(sjd) / "test.fits"),
         "data": numpy.array([]),
         "header": {
             "KEY1": ["value", "A comment"],

--- a/tests/actor/conftest.py
+++ b/tests/actor/conftest.py
@@ -6,21 +6,31 @@
 # @Filename: conftest.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
+from __future__ import annotations
+
 import os
 import pathlib
+
+from typing import TYPE_CHECKING, Generator
 
 import numpy
 import pytest
 import pytest_asyncio
+from pytest_mock import MockFixture
 
 import clu.testing
 from clu.actor import AMQPBaseActor
-from sdsstools import merge_config, read_yaml_file
+from sdsstools import get_sjd, merge_config, read_yaml_file
 
 from archon import config
 from archon.actor import ArchonActor
+from archon.actor.recovery import ExposureRecovery
 from archon.controller.controller import ArchonController
 from archon.controller.maskbits import ControllerStatus
+
+
+if TYPE_CHECKING:
+    from archon.actor.delegate import FetchDataDict
 
 
 @pytest.fixture()
@@ -97,3 +107,42 @@ def delegate(actor: ArchonActor, monkeypatch, tmp_path: pathlib.Path, mocker):
     monkeypatch.setitem(actor.config["files"], "data_dir", str(files_data_dir))
 
     yield actor.exposure_delegate
+
+
+@pytest.fixture()
+def exposure_recovery(controller: ArchonController, mocker: MockFixture):
+    mocker.patch.object(
+        controller,
+        "fetch",
+        return_value=numpy.ones((1000, 3000)),
+    )
+
+    _exposure_recovery = ExposureRecovery({"sp1": controller})
+
+    yield _exposure_recovery
+
+
+@pytest.fixture()
+def controller_info(test_config: dict) -> Generator[dict, None, None]:
+    yield test_config["controllers"]
+
+
+@pytest.fixture()
+def fetch_data(tmp_path: pathlib.Path):
+    sjd = get_sjd()
+
+    _fetch_data: FetchDataDict = {
+        "buffer": 1,
+        "ccd": "r1",
+        "controller": "sp1",
+        "exposure_no": 1,
+        "filename": str(tmp_path / str(get_sjd()) / "test.fits"),
+        "data": numpy.array([]),
+        "header": {
+            "KEY1": ["value", "A comment"],
+            "FILENAME": ["", ""],
+            "EXPOSURE": ["", ""],
+        },
+    }
+
+    yield _fetch_data

--- a/tests/actor/conftest.py
+++ b/tests/actor/conftest.py
@@ -146,3 +146,13 @@ def fetch_data(tmp_path: pathlib.Path):
     }
 
     yield _fetch_data
+
+
+@pytest.fixture()
+def recovery_lockfile(fetch_data: FetchDataDict, exposure_recovery: ExposureRecovery):
+    exposure_recovery.update(fetch_data)
+    lockfile = pathlib.Path(fetch_data["filename"] + ".lock")
+
+    yield lockfile
+
+    lockfile.unlink(missing_ok=True)

--- a/tests/actor/test_actor.py
+++ b/tests/actor/test_actor.py
@@ -6,9 +6,20 @@
 # @Filename: test_actor.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 
+from __future__ import annotations
+
+import pathlib
+
+from typing import TYPE_CHECKING
+
 import pytest
 
 from archon.actor import ArchonActor
+from archon.actor.recovery import ExposureRecovery
+
+
+if TYPE_CHECKING:
+    from archon.actor.delegate import FetchDataDict
 
 
 async def test_actor(actor: ArchonActor):
@@ -29,3 +40,25 @@ async def test_ping(actor):
 async def test_actor_no_config():
     with pytest.raises(RuntimeError):
         ArchonActor.from_config(None)
+
+
+async def test_actor_recover_exposures(
+    actor: ArchonActor,
+    exposure_recovery: ExposureRecovery,
+    fetch_data: FetchDataDict,
+):
+    exposure_recovery.update(fetch_data)
+
+    filename = pathlib.Path(fetch_data["filename"])
+
+    actor.config["files"]["data_dir"] = filename.parents[1]
+    recovered = await actor._recover_exposures()
+
+    assert filename.exists()
+    assert recovered is not None and len(recovered) == 1
+
+
+async def test_actor_recover_exposures_invalid_path(actor: ArchonActor):
+    actor.config["files"]["data_dir"] = "/bad/path"
+    recovered = await actor._recover_exposures()
+    assert recovered is None

--- a/tests/actor/test_command_recover.py
+++ b/tests/actor/test_command_recover.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2023-12-01
+# @Filename: test_command_recover.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import pathlib
+
+from typing import TYPE_CHECKING
+
+from pytest_mock import MockerFixture
+
+from sdsstools import get_sjd
+
+
+if TYPE_CHECKING:
+    from archon.actor.actor import ArchonActor
+
+
+async def test_recover(actor: ArchonActor, recovery_lockfile: pathlib.Path):
+    command = await actor.invoke_mock_command(f"recover {recovery_lockfile!s}")
+    await command
+
+    fits_file = recovery_lockfile.parent / recovery_lockfile.name.replace(".lock", "")
+    assert fits_file.exists()
+
+    assert command.status.did_succeed
+    assert len(command.replies[-1].message["filenames"]) == 1
+
+
+async def test_recover_no_path(actor: ArchonActor, mocker: MockerFixture):
+    recover_mock = mocker.patch.object(actor.exposure_recovery, "recover")
+
+    command = await actor.invoke_mock_command("recover")
+    await command
+
+    assert command.status.did_succeed
+    assert len(command.replies[-1].message["filenames"]) == 0
+
+    sjd = get_sjd()
+    recover_mock.assert_called_once_with(
+        mocker.ANY,
+        path=pathlib.Path(f"/var/tmp/{sjd}"),
+        checksum_file=None,
+        checksum_mode="md5",
+        delete_lock=True,
+        write_checksum=False,
+    )
+
+
+async def test_recover_bad_path(actor: ArchonActor):
+    command = await actor.invoke_mock_command("recover /bad/path/to/file.lock")
+    await command
+
+    assert command.status.did_fail

--- a/tests/actor/test_delegate.py
+++ b/tests/actor/test_delegate.py
@@ -85,7 +85,7 @@ async def test_delegate_expose_invalid_checksum(delegate: ExposureDelegate):
     )
 
     assert result is True
-    assert command.replies[-1].message["text"].startswith("Invalid checksum")
+    assert command.replies[-2].message["text"].startswith("Invalid checksum")
 
 
 async def test_delegate_expose_top_mode(delegate: ExposureDelegate, mocker):

--- a/tests/actor/test_recovery.py
+++ b/tests/actor/test_recovery.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2023-12-01
+# @Filename: test_recovery.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+
+from __future__ import annotations
+
+import os.path
+import pathlib
+
+from typing import TYPE_CHECKING, Generator
+
+import numpy
+import pytest
+from pytest_mock import MockerFixture
+
+from clu import Command
+from sdsstools import get_sjd
+
+from archon.actor.actor import ArchonActor
+from archon.actor.delegate import ExposureDelegate
+from archon.actor.recovery import ExposureRecovery
+from archon.exceptions import ArchonError
+
+
+if TYPE_CHECKING:
+    from archon.actor.delegate import FetchDataDict
+    from archon.controller.controller import ArchonController
+
+
+@pytest.fixture()
+def exposure_recovery(controller: ArchonController, mocker: MockerFixture):
+    mocker.patch.object(
+        controller,
+        "fetch",
+        return_value=numpy.ones((1000, 3000)),
+    )
+
+    _exposure_recovery = ExposureRecovery({"sp1": controller})
+
+    yield _exposure_recovery
+
+
+@pytest.fixture()
+def controller_info(test_config: dict) -> Generator[dict, None, None]:
+    yield test_config["controllers"]
+
+
+@pytest.fixture()
+def fetch_data(tmp_path: pathlib.Path):
+    _fetch_data: FetchDataDict = {
+        "buffer": 1,
+        "ccd": "r1",
+        "controller": "sp1",
+        "exposure_no": 1,
+        "filename": str(tmp_path / "test.fits"),
+        "data": numpy.array([]),
+        "header": {
+            "KEY1": ["value", "A comment"],
+            "FILENAME": ["", ""],
+            "EXPOSURE": ["", ""],
+        },
+    }
+
+    yield _fetch_data
+
+
+def test_recovery_update_unlink(
+    exposure_recovery: ExposureRecovery,
+    fetch_data: FetchDataDict,
+):
+    """Tests that the recovery is updated correctly."""
+
+    exposure_recovery.update(fetch_data)
+    assert os.path.exists(fetch_data["filename"] + ".lock")
+
+    with pytest.raises(FileExistsError):
+        exposure_recovery.unlink(fetch_data)
+
+    exposure_recovery.unlink(fetch_data, force=True)
+    assert not os.path.exists(fetch_data["filename"] + ".lock")
+
+
+def test_recovery_update_unlink_filename(
+    exposure_recovery: ExposureRecovery,
+    fetch_data: FetchDataDict,
+):
+    exposure_recovery.update(fetch_data)
+    assert os.path.exists(fetch_data["filename"] + ".lock")
+
+    exposure_recovery.unlink(fetch_data["filename"])
+    assert not os.path.exists(fetch_data["filename"] + ".lock")
+
+
+async def test_recovery_update_recover(
+    exposure_recovery: ExposureRecovery,
+    fetch_data: FetchDataDict,
+    controller_info: dict,
+):
+    exposure_recovery.update(fetch_data)
+    lock_path = fetch_data["filename"] + ".lock"
+    assert os.path.exists(lock_path)
+
+    recovered = await exposure_recovery.recover(
+        controller_info,
+        files=[lock_path],
+        write_checksum=True,
+    )
+    assert len(recovered) == 1
+
+    filename = pathlib.Path(fetch_data["filename"])
+    assert filename.exists()
+
+    sjd = get_sjd()
+    checksum_path = filename.parent / f"{sjd}.md5sum"
+    assert checksum_path.exists()
+
+
+async def test_recovery_lockfile_does_not_exist(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+    actor: ArchonActor,
+):
+    command = Command("", actor=actor)
+
+    with exposure_recovery.set_command(command):
+        results = await exposure_recovery.recover(
+            controller_info,
+            path="/bad/path/to/file.lock",
+        )
+
+    assert results == []
+    assert "does not exist" in command.replies[-1].message["text"]
+
+
+async def test_recovery_invalid_controller(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+    actor: ArchonActor,
+    fetch_data: FetchDataDict,
+):
+    fetch_data["controller"] = "sp2"
+    exposure_recovery.update(fetch_data)
+
+    command = Command("", actor=actor)
+
+    with exposure_recovery.set_command(command):
+        results = await exposure_recovery.recover(
+            controller_info,
+            files=[fetch_data["filename"] + ".lock"],
+        )
+
+    assert results == []
+    assert "Cannot find controller" in command.replies[-1].message["text"]
+
+
+async def test_recovery_two_files(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+    fetch_data: FetchDataDict,
+    tmp_path: pathlib.Path,
+):
+    fetch_data1 = fetch_data.copy()
+    fetch_data2 = fetch_data.copy()
+
+    fetch_data1["filename"] = str(tmp_path / "test_r1.fits")
+    fetch_data1["ccd"] = "r1"
+
+    fetch_data2["filename"] = str(tmp_path / "test_b1.fits")
+    fetch_data1["ccd"] = "b1"
+
+    exposure_recovery.update([fetch_data1, fetch_data2])
+
+    recovered = await exposure_recovery.recover(controller_info, path=tmp_path)
+    assert len(recovered) == 2
+
+    assert os.path.exists(fetch_data1["filename"])
+    assert os.path.exists(fetch_data2["filename"])
+
+
+async def test_recovery_path_or_files(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+):
+    with pytest.raises(ValueError):
+        await exposure_recovery.recover(controller_info)
+
+
+async def test_recovery_path_and_files(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+):
+    with pytest.raises(ValueError):
+        await exposure_recovery.recover(
+            controller_info,
+            path="/path/to/file",
+            files=["/path/to/file"],
+        )
+
+
+async def test_recovery_excluded_cameras(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+    actor: ArchonActor,
+    fetch_data: FetchDataDict,
+):
+    exposure_recovery.update(fetch_data)
+
+    command = Command("", actor=actor)
+    with exposure_recovery.set_command(command):
+        results = await exposure_recovery.recover(
+            controller_info,
+            path=fetch_data["filename"] + ".lock",
+            excluded_cameras=["r1"],
+        )
+
+    assert results == []
+    assert "Skipping exposure" in command.replies[-1].message["text"]
+
+
+async def test_recovery_failed_to_write(
+    exposure_recovery: ExposureRecovery,
+    controller_info: dict,
+    actor: ArchonActor,
+    fetch_data: FetchDataDict,
+    mocker: MockerFixture,
+):
+    mocker.patch.object(
+        ExposureDelegate,
+        "write_to_disk",
+        side_effect=ArchonError,
+    )
+
+    exposure_recovery.update(fetch_data)
+
+    command = Command("", actor=actor)
+    with exposure_recovery.set_command(command):
+        results = await exposure_recovery.recover(
+            controller_info,
+            path=fetch_data["filename"] + ".lock",
+        )
+
+    assert results == []
+    assert "Failed to write" in command.replies[-1].message["text"]

--- a/tests/actor/test_recovery.py
+++ b/tests/actor/test_recovery.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 import os.path
 import pathlib
 
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 
-import numpy
 import pytest
 from pytest_mock import MockerFixture
 
@@ -28,44 +27,6 @@ from archon.exceptions import ArchonError
 
 if TYPE_CHECKING:
     from archon.actor.delegate import FetchDataDict
-    from archon.controller.controller import ArchonController
-
-
-@pytest.fixture()
-def exposure_recovery(controller: ArchonController, mocker: MockerFixture):
-    mocker.patch.object(
-        controller,
-        "fetch",
-        return_value=numpy.ones((1000, 3000)),
-    )
-
-    _exposure_recovery = ExposureRecovery({"sp1": controller})
-
-    yield _exposure_recovery
-
-
-@pytest.fixture()
-def controller_info(test_config: dict) -> Generator[dict, None, None]:
-    yield test_config["controllers"]
-
-
-@pytest.fixture()
-def fetch_data(tmp_path: pathlib.Path):
-    _fetch_data: FetchDataDict = {
-        "buffer": 1,
-        "ccd": "r1",
-        "controller": "sp1",
-        "exposure_no": 1,
-        "filename": str(tmp_path / "test.fits"),
-        "data": numpy.array([]),
-        "header": {
-            "KEY1": ["value", "A comment"],
-            "FILENAME": ["", ""],
-            "EXPOSURE": ["", ""],
-        },
-    }
-
-    yield _fetch_data
 
 
 def test_recovery_update_unlink(


### PR DESCRIPTION
This PR introduces a framework for recovering exposures that failed to write to disk.

During readout, once the buffer has been read and the header compiled, a lockfile is created with the same name as the final image + `.lock`. The lockfile contains the `FetchDataDict` with the exception of the data itself.

If an error prevents the image from being written, the lockfile can be used to recover the image. The `ExposureRecovery` class contains tools to update the lockfile and use it to recover the image.

During recovery, the lockfile is read and the buffer that contained the original data is fetched again. Wit that and the header from the lockfile it's possible to write the actual FITS file to disk.

Recovery happens automatically on the `/data/.../MJD` directory when the actor starts. It's also possible to trigger it manually with the `recover` command.