### PR TITLE
Improve abort command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Next version
+
+### ✨ Improved
+
+* [#49](https://github.com/sdss/archon/pull/49) Improve the `abort` command. When an integration or readout is ongoing, the current task is stored in the delegate and cancelled if an abort happens. This should immediately cancel the command and any controller action. To perform a full abort, one should also run the `reset` command, which will reset the controller, including a reset timings, or call `abort --reset`.
+
+
 ## 0.13.4 - February 27, 2024
 
 ### ✨ Improved

--- a/archon/actor/commands/expose.py
+++ b/archon/actor/commands/expose.py
@@ -322,6 +322,8 @@ async def abort(
         # This will also cancel any ongoing exposure or readout.
         delegate.fail("Exposure was aborted")
 
+    await delegate.shutter(False)  # Close the shutter.
+
     if reset:
         command.debug(text="Resetting controllers")
         try:

--- a/archon/actor/commands/expose.py
+++ b/archon/actor/commands/expose.py
@@ -304,7 +304,7 @@ async def abort(
     delegate = command.actor.exposure_delegate
     expose_data = delegate.expose_data
 
-    if delegate is None or delegate.command is None:
+    if delegate is None or delegate._command is None:
         return command.fail(error="Expose command is not running.")
 
     scontr: list[ArchonController]

--- a/archon/actor/commands/expose.py
+++ b/archon/actor/commands/expose.py
@@ -314,6 +314,9 @@ async def abort(
         scontr = expose_data.controllers
 
     command.debug(text="Aborting exposures")
+
+    await delegate.shutter(False)  # Close the shutter.
+
     try:
         await asyncio.gather(*[contr.abort(readout=False) for contr in scontr])
     except ArchonError as err:
@@ -321,8 +324,6 @@ async def abort(
     finally:
         # This will also cancel any ongoing exposure or readout.
         delegate.fail("Exposure was aborted")
-
-    await delegate.shutter(False)  # Close the shutter.
 
     if reset:
         command.debug(text="Resetting controllers")

--- a/archon/actor/commands/reset.py
+++ b/archon/actor/commands/reset.py
@@ -25,7 +25,7 @@ async def reset(command: Command, controller: ArchonController):
     assert command.actor
 
     try:
-        await controller.reset()
+        await controller.reset(reset_timing=True)
         command.actor.expose_data = None
     except (ArchonControllerError, ArchonError) as err:
         return error_controller(command, controller, f"Failed resetting: {err}")

--- a/archon/controller/controller.py
+++ b/archon/controller/controller.py
@@ -752,7 +752,13 @@ class ArchonController(Device):
 
         self.auto_flush = mode
 
-    async def reset(self, autoflush=True, release_timing=True, update_status=True):
+    async def reset(
+        self,
+        autoflush: bool = True,
+        release_timing: bool = True,
+        reset_timing: bool = False,
+        update_status: bool = True,
+    ):
         """Resets timing and discards current exposures."""
 
         self._parse_params()
@@ -774,9 +780,15 @@ class ArchonController(Device):
             for param in default_parameters:
                 await self.set_param(param, default_parameters[param])
 
+        timing_commands: list[str] = []
+        if reset_timing:
+            release_timing = True
+            timing_commands.append("RESETTIMING")
+
         if release_timing:
             log.info(f"{self.name}: restarting timing .")
-            for cmd_str in ["RELEASETIMING"]:
+            timing_commands.append("RELEASETIMING")
+            for cmd_str in timing_commands:
                 cmd = await self.send_command(cmd_str, timeout=1)
                 if not cmd.succeeded():
                     self.update_status(ControllerStatus.ERROR)

--- a/tests/actor/test_command_expose.py
+++ b/tests/actor/test_command_expose.py
@@ -160,7 +160,7 @@ async def test_expose_abort(
     assert abort.status.did_succeed
 
     assert expose_command.status.did_fail
-    assert expose_command.replies[-1].message == "Exposure was aborted"
+    assert expose_command.replies[-1].message["error"] == "Exposure was aborted"
 
     assert delegate._current_task is None
 

--- a/tests/actor/test_command_expose.py
+++ b/tests/actor/test_command_expose.py
@@ -158,7 +158,9 @@ async def test_expose_abort(
     await asyncio.sleep(0.5)
 
     assert abort.status.did_succeed
+
     assert expose_command.status.did_fail
+    assert expose_command.replies[-1].message == "Exposure was aborted"
 
     assert delegate._current_task is None
 
@@ -172,10 +174,10 @@ async def test_expose_abort_reset_fails(
     controller: ArchonController,
     mocker: MockFixture,
 ):
-    mocker.patch.object(controller, "reset", side_effect=ArchonError)
-
     await actor.invoke_mock_command("expose --no-readout 1")
     await asyncio.sleep(0.5)
+
+    mocker.patch.object(controller, "reset", side_effect=ArchonError)
 
     abort = await actor.invoke_mock_command("abort --reset")
     await abort

--- a/tests/actor/test_command_expose.py
+++ b/tests/actor/test_command_expose.py
@@ -134,13 +134,19 @@ async def test_expose_read_expose_fails(delegate, actor: ArchonActor, mocker):
 
 
 async def test_expose_abort(delegate, actor: ArchonActor):
-    await actor.invoke_mock_command("expose --no-readout 1")
+
+    expose_command = await actor.invoke_mock_command("expose --no-readout 1")
     await asyncio.sleep(0.5)
 
     abort = await actor.invoke_mock_command("abort")
     await abort
 
+    await asyncio.sleep(0.5)
+
     assert abort.status.did_succeed
+    assert expose_command.status.did_fail
+
+    assert delegate._current_task is None
 
 
 async def test_expose_abort_no_expose_data(delegate, actor: ArchonActor):
@@ -152,7 +158,7 @@ async def test_expose_abort_no_expose_data(delegate, actor: ArchonActor):
     abort = await actor.invoke_mock_command("abort")
     await abort
 
-    assert abort.status.did_fail
+    assert abort.status.did_succeed
 
 
 async def test_expose_abort_no_expose_data_force(delegate, actor: ArchonActor):
@@ -161,19 +167,7 @@ async def test_expose_abort_no_expose_data_force(delegate, actor: ArchonActor):
 
     actor.exposure_delegate.expose_data = None
 
-    abort = await actor.invoke_mock_command("abort --force")
-    await abort
-
-    assert abort.status.did_succeed
-
-
-async def test_expose_abort_no_expose_data_all(delegate, actor: ArchonActor):
-    await actor.invoke_mock_command("expose --no-readout 1")
-    await asyncio.sleep(0.5)
-
-    actor.exposure_delegate.expose_data = None
-
-    abort = await actor.invoke_mock_command("abort --all")
+    abort = await actor.invoke_mock_command("abort")
     await abort
 
     assert abort.status.did_succeed


### PR DESCRIPTION
Improves the `abort` command. When an integration or readout is ongoing, the current task is stored in the delegate and cancelled if an abort happens. This should immediately cancel the command and any controller action. To perform a full abort, one should also run the `reset` command, which will reset the controller, including a reset timings.